### PR TITLE
fix null str_replace

### DIFF
--- a/Model/CheckoutConfigProvider.php
+++ b/Model/CheckoutConfigProvider.php
@@ -37,7 +37,7 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
         $baseApiUrl = substr($tmpEnvironment->getStageBaseUrl(), 0, -3);
         $output['api_base_url'] = $baseApiUrl;
         $output['backend_base_url'] = $this->storeManager->getStore()->getBaseUrl();
-        if(empty($this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers'))){
+        if(empty($this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers')) || $this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers') == NULL){
             $output['available_carriers'] = null;
         } else {
             $output['available_carriers'] = str_replace(

--- a/Model/CheckoutConfigProvider.php
+++ b/Model/CheckoutConfigProvider.php
@@ -37,9 +37,13 @@ class CheckoutConfigProvider implements \Magento\Checkout\Model\ConfigProviderIn
         $baseApiUrl = substr($tmpEnvironment->getStageBaseUrl(), 0, -3);
         $output['api_base_url'] = $baseApiUrl;
         $output['backend_base_url'] = $this->storeManager->getStore()->getBaseUrl();
-        $output['available_carriers'] = str_replace(
-            ' ', '', $this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers')
-        );
+        if(empty($this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers'))){
+            $output['available_carriers'] = null;
+        } else {
+            $output['available_carriers'] = str_replace(
+                ' ', '', $this->scopeConfig->getValue('carriers/parcelshopPicker/enabledcarriers')
+            );
+        }
         return $output;
     }
 }


### PR DESCRIPTION
main.CRITICAL: Exception: Deprecated Functionality: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /var/www/html/vendor/wuunder/magento2-connector/Model/Ch eckoutConfigProvider.php on line 41 in /var/www/html/vendor/magento/framework/App/ErrorHandler.php:62