### PR TITLE
Error: Class "Zend\Log\Writer\Stream" not found

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -14,8 +14,8 @@ class Data extends AbstractHelper
     public function log($message)
     {
         if ($this->_isLoggingEnabled()) {
-            $writer = new \Zend\Log\Writer\Stream(BP . '/var/log/wuunder.log');
-            $logger = new \Zend\Log\Logger();
+            $writer = new \Zend_Log_Writer_Stream(BP . '/var/log/wuunder.log');
+            $logger = new \Zend_Log();
             $logger->addWriter($writer);
             $logger->info($message);
         }


### PR DESCRIPTION
Error: Class "Zend\Log\Writer\Stream" not found in Magento 2.4.5-p.3